### PR TITLE
Fix encoding to prevent SytnaxError

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding=utf-8
 import sys
 import cv2
 import argparse


### PR DESCRIPTION
The character encoding is called `utf-8`, not `utf8`.
The latter causes the following exception under Python 3.7.4:

```
SyntaxError: encoding problem: utf8
````

Please see [PEP 263](https://www.python.org/dev/peps/pep-0263/) for more detailed information about the `coding` directive.